### PR TITLE
Implemented Fake LODs for .agp Autosplit Objects

### DIFF
--- a/io_scene_xplane_ext/Helpers/agp_utils.py
+++ b/io_scene_xplane_ext/Helpers/agp_utils.py
@@ -432,3 +432,30 @@ def recursively_split_objects(in_object:bpy.types.Object):
         resulting_objects.extend(recursively_split_objects(child))
 
     return resulting_objects
+
+def add_fake_lod_obj_to_collections(lods: int, size: int):
+    verts = [] #type: list[geometery_utils.xp_vertex]
+    v1 = geometery_utils.xp_vertex(-size, -size, -size, 0, 0, 1, 0, 0)
+    v2 = geometery_utils.xp_vertex(-size, size, -size, 0, 0, 1, 0, 0)
+    v3 = geometery_utils.xp_vertex(size, -size, -size, 0, 0, 1, 0, 0)
+    v4 = geometery_utils.xp_vertex(size, size, -size, 0, 0, 1, 0, 0)
+    verts.append(v1)
+    verts.append(v2)
+    verts.append(v3)
+    verts.append(v4)
+
+    indicies = [1, 2, 0, 1, 3, 2]
+
+    fake_lod_obj = geometery_utils.create_obj_from_draw_call(verts, indicies, "Fake LOD")
+
+    if lods > 0:
+        fake_lod_obj.xplane.override_lods = True
+        fake_lod_obj.xplane.lod[0] = True
+    if size > 1:
+        fake_lod_obj.xplane.lod[1] = True
+    if size > 2:
+        fake_lod_obj.xplane.lod[2] = True
+    if size > 3:
+        fake_lod_obj.xplane.lod[3] = True
+
+    return fake_lod_obj

--- a/io_scene_xplane_ext/props.py
+++ b/io_scene_xplane_ext/props.py
@@ -644,6 +644,19 @@ class PROP_agp_obj(bpy.types.PropertyGroup):
         default=""
     ) # type: ignore
 
+    autosplit_do_fake_lods: bpy.props.BoolProperty(
+        name="Fake LODs",
+        description="Whether to add objects of a fixed size to all LODs of the autosplit object for consistent LOD behavior",
+        default=False
+    ) # type: ignore
+
+    autosplit_fake_lods_size: bpy.props.FloatProperty(
+        name="Fake LODs Size",
+        description="The size of the fake LODs for the autosplit object. This is the size of the bounding box of the fake LODs",
+        default=100.0,
+        min=1.0
+    ) # type: ignore
+
     #Autosplit lod settings
     autosplit_lod_count: bpy.props.IntProperty(name="Autosplit LOD Count", description="The number of LODs to use for autosplit objects", default=0, min=0, max=4) # type: ignore
     autosplit_lod_1_min: bpy.props.FloatProperty(name="Autosplit LOD 1 Min Distance", description="The minimum distance for the first LOD of autosplit objects", default=0.0, min=0.0) # type: ignore

--- a/io_scene_xplane_ext/ui.py
+++ b/io_scene_xplane_ext/ui.py
@@ -404,6 +404,10 @@ class MENU_agp_obj(bpy.types.Panel):
                 layout.separator()
                 layout.prop(agp_obj, "autosplit_obj_name")
                 layout.separator()
+                layout.prop(agp_obj, "autosplit_do_fake_lods")
+                if agp_obj.autosplit_do_fake_lods:
+                    layout.prop(agp_obj, "autosplit_fake_lods_size")
+                layout.separator()
                 layout.prop(agp_obj, "autosplit_lod_count")
                 if  agp_obj.autosplit_lod_count > 0:
                     row = layout.row()


### PR DESCRIPTION
Fake LODs allow consistent LOD behavior between multiple individual .objs that make up an autosplit object in a .agp. Fake LODs are an upside-down plane of a fixed size which is put in every LOD in every .obj resulting from a .agp. It's settings can be found in the Agp Object settings when the type is set to Autosplit Object. It being on/off can be set, and it's size can be set.